### PR TITLE
12 usb works but is slow

### DIFF
--- a/Inc/app/usb_task.h
+++ b/Inc/app/usb_task.h
@@ -1,0 +1,16 @@
+#ifndef USB_TASK_H
+#define USB_TASK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+void usb_task(void * argument);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_TASK_H */

--- a/Inc/modbus/modbus_port_ownership.h
+++ b/Inc/modbus/modbus_port_ownership.h
@@ -6,5 +6,6 @@
 void modbus_port_ownership_init(void);
 bool modbus_port_ownership_try_claim(void);
 void modbus_port_ownership_refresh(void);
+void modbus_port_ownership_release(void);
 
 #endif /* MODBUS_PORT_OWNERSHIP_H */

--- a/Src/app/system.c
+++ b/Src/app/system.c
@@ -32,6 +32,8 @@
 #include "usb_device.h"
 #endif
 
+#include "usb_task.h"
+
 /* Idle task — required by configSUPPORT_STATIC_ALLOCATION */
 static StaticTask_t idleTaskTcb;
 static StackType_t  idleTaskStack[configMINIMAL_STACK_SIZE];
@@ -48,26 +50,6 @@ static StackType_t  modbusUartTaskStack[MODBUS_TASK_STACK_SIZE];
 static TaskHandle_t usbTaskHandle;
 static StaticTask_t usbTaskTcb;
 static StackType_t  usbTaskStack[USB_TASK_STACK_SIZE];
-
-/**
- * @brief USB task — initialises the USB CDC port then runs the Modbus USB handler.
- *
- * modbus_usb_init() must be called before MX_USB_Device_Init() so the RX stream
- * buffer exists before the first USB ISR fires.
- *
- * USBD_malloc is mapped to USBD_static_malloc (Inc/hw/usbd_conf.h) — no
- * FreeRTOS heap dependency; safe to call from task context.
- */
-static void usb_task(void * argument)
-{
-    (void)argument;
-    modbus_usb_init();
-    MX_USB_Device_Init();
-    for (;;)
-    {
-        (void)modbus_usb_run();   /* sleeps until USB data arrives */
-    }
-}
 #endif
 
 void system_app_init(void)

--- a/Src/app/usb_task.c
+++ b/Src/app/usb_task.c
@@ -1,0 +1,42 @@
+#include "usb_task.h"
+#include "usb_device.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "main.h"
+#include "portserial.h"
+
+
+#if COMMS_MODBUS_PORT != COMMS_MODBUS_UART
+#include "modbus_usb.h"
+#endif
+
+/**
+ * @brief USB task — initialises the USB CDC port then runs the Modbus USB handler.
+ *
+ * modbus_usb_init() must be called before MX_USB_Device_Init() so the RX stream
+ * buffer exists before the first USB ISR fires.
+ *
+ * USBD_malloc is mapped to USBD_static_malloc (Inc/hw/usbd_conf.h) — no
+ * FreeRTOS heap dependency; safe to call from task context.
+ */
+void usb_task(void * argument)
+{
+    (void)argument;
+
+    #if COMMS_MODBUS_PORT != COMMS_MODBUS_UART
+    modbus_usb_init();
+    #endif
+
+    MX_USB_Device_Init();
+    for (;;)
+    {
+        #if COMMS_MODBUS_PORT != COMMS_MODBUS_UART
+        (void)modbus_usb_run();   /* sleeps until USB data arrives */
+        #else
+        // Just sleep nothing to do, nothing implemented
+        vtaskDelay(pdMS_TO_TICKS(15000));
+        #endif
+    }
+}

--- a/Src/hw/usbd_cdc_if.c
+++ b/Src/hw/usbd_cdc_if.c
@@ -220,11 +220,9 @@ uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
   */
 static int8_t CDC_TransmitCplt_FS(uint8_t *Buf, uint32_t *Len, uint8_t epnum)
 {
-  /* No action needed.  Modbus is strictly synchronous (one request, one
-   * response) so the master will not send the next request until after it
-   * has received the response.  By the time CDC_Receive_FS fires for the
-   * next frame, the previous CDC_Transmit_FS transfer is guaranteed complete.
-   * There is no need to track transmit completion at the application level.  */
+  /* No action needed.  portserial_usb_flush_tx retries on USBD_BUSY with
+   * 1 ms delays, so by the time a second response is attempted TxState will
+   * have been cleared here already.                                          */
   UNUSED(Buf);
   UNUSED(Len);
   UNUSED(epnum);

--- a/Src/modbus/modbus_port_ownership.c
+++ b/Src/modbus/modbus_port_ownership.c
@@ -33,7 +33,7 @@
 #include "semphr.h"
 #include "timers.h"
 
-#define PORT_OWNER_TIMEOUT_MS   500u
+#define PORT_OWNER_TIMEOUT_MS   100u
 
 static StaticSemaphore_t portOwnerSemBuf;
 static SemaphoreHandle_t portOwnerSem;
@@ -115,5 +115,23 @@ void modbus_port_ownership_refresh(void)
 {
 #if COMMS_MODBUS_PORT == COMMS_MODBUS_DYNAMIC
     (void)xTimerReset(portOwnerTimer, 0);
+#endif
+}
+
+/**
+ * @brief Explicitly release port ownership after a completed TX cycle.
+ *
+ * Called from vMBPortSerialEnable(TRUE, FALSE) the moment the USB response is
+ * sent, so the next request can claim ownership immediately rather than waiting
+ * for the PORT_OWNER_TIMEOUT_MS timer.  The timer is stopped to prevent a
+ * redundant semaphore give after the explicit release.
+ *
+ * In non-DYNAMIC builds this is a no-op.
+ */
+void modbus_port_ownership_release(void)
+{
+#if COMMS_MODBUS_PORT == COMMS_MODBUS_DYNAMIC
+    (void)xTimerStop(portOwnerTimer, 0);
+    (void)xSemaphoreGive(portOwnerSem);
 #endif
 }

--- a/Src/modbus/portserial.c
+++ b/Src/modbus/portserial.c
@@ -75,6 +75,7 @@
 #include "port.h"
 #include "port_internal.h"
 #include "portserial_usb.h"
+#include "modbus_port_ownership.h"
 
 #include "FreeRTOS.h"
 #include "task.h"
@@ -317,9 +318,12 @@ void vMBPortSerialEnable( BOOL rxEnable, BOOL txEnable )
             /* --- USB restore ---
              * Called by xMBRTUTransmitFSM() when the last TX byte is sent.
              * Clear the USB flag so subsequent FreeModbus calls go back to
-             * UART, and re-enable the UART RX interrupt.                      */
+             * UART, re-enable the UART RX interrupt, and release ownership
+             * immediately so the next USB request is not blocked until the
+             * 100ms inactivity timer fires.                                    */
             bUsbActive = false;
             MB_SERIAL_ENABLE_RX_IRQ();
+            modbus_port_ownership_release();
         }
         /* Any other combination (both true/false) is not issued by FreeModbus
          * during normal operation — fall through and return without touching

--- a/Src/modbus/portserial_usb.c
+++ b/Src/modbus/portserial_usb.c
@@ -23,6 +23,7 @@
 
 #include "FreeRTOS.h"
 #include "stream_buffer.h"
+#include "task.h"
 
 #include <assert.h>
 
@@ -37,6 +38,8 @@ StreamBufferHandle_t        usbRxStream;
 
 static uint8_t  usbTxBuf[USB_TX_BUF_SIZE];
 static uint16_t usbTxLen;
+
+#define MAX_RETRY_ATTEMPTS  5u
 
 /**
  * @brief Initialise the USB serial port layer.
@@ -78,18 +81,30 @@ void portserial_usb_put_byte(uint8_t const b)
  * Sends the accumulated response frame as a single USB CDC transfer, then
  * resets the buffer length to zero for the next frame.
  *
- * @note CDC_Transmit_FS returns USBD_BUSY if a previous transfer has not
- *       completed.  At Modbus data rates this should never happen, but the
- *       return value is cast to void — if needed, add retry logic here.
- *       @todo [2026-04-25] Add optional vTaskDelay(pdMS_TO_TICKS(2u)) pre-delay
- *             if strict host applications require a t3.5 silence before the
- *             response.
+ * @note CDC_Transmit_FS returns USBD_BUSY when the previous IN transfer has
+ *       not yet been acknowledged by the host.  A fast master can receive the
+ *       USB IN packet and immediately send the next OUT packet before the
+ *       TransmitCplt interrupt fires and clears TxState.  Retrying with 1 ms
+ *       delays handles this: the IN transfer completes within 1-2 ms on USB
+ *       Full Speed, so MAX_RETRY_ATTEMPTS gives adequate headroom.
  */
 void portserial_usb_flush_tx(void)
 {
-    if (usbTxLen > 0u)
+    if (0u != usbTxLen)
     {
-        (void)CDC_Transmit_FS(usbTxBuf, usbTxLen);
+        uint8_t result;
+        uint8_t attempts = 0u;
+
+        do
+        {
+            result = CDC_Transmit_FS(usbTxBuf, usbTxLen);
+            if (USBD_OK != result)
+            {
+                vTaskDelay(pdMS_TO_TICKS(1u));
+                attempts++;
+            }
+        } while ((USBD_OK != result) && (attempts < MAX_RETRY_ATTEMPTS));
+
         usbTxLen = 0u;
     }
 }


### PR DESCRIPTION
Added retry look on usb tx failure or busy
Updated ownership of line to release at 100ms instead of 500ms.
Added release ownership function so after TX done, the ownership is released immediatly. 