### PR TITLE
Replace raw extern handles with getter functions across hw layer

### DIFF
--- a/Inc/hw/crc.h
+++ b/Inc/hw/crc.h
@@ -32,7 +32,8 @@ extern "C" {
 
 /* USER CODE END Includes */
 
-extern CRC_HandleTypeDef hcrc;
+/** Returns a pointer to the CRC handle owned by crc.c. */
+CRC_HandleTypeDef * CRC_GetHandle(void);
 
 /* USER CODE BEGIN Private defines */
 

--- a/Inc/hw/usart.h
+++ b/Inc/hw/usart.h
@@ -30,8 +30,8 @@ extern "C" {
 
 #include <stdbool.h>
 
-// @todo [2026-4-12] Decouple how the handle is passed around.  It's ugly.
-extern UART_HandleTypeDef huart2;
+/** Returns a pointer to the USART2 handle owned by usart.c. */
+UART_HandleTypeDef * USART2_GetHandle(void);
 
 
 void usart_uart_init(uint8_t  const usartNum,

--- a/Inc/hw/usb_device.h
+++ b/Inc/hw/usb_device.h
@@ -30,6 +30,9 @@
 /** USB Device initialization function. */
 void MX_USB_Device_Init(void);
 
+/** Returns a pointer to the USB device handle owned by usb_device.c. */
+USBD_HandleTypeDef * USB_GetDeviceHandle(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -313,6 +313,45 @@ The `.project` and `.cproject` files are committed.  Select the **Debug** build 
 
 ---
 
+## Design Decisions
+
+### `extern` Usage Policy
+
+#### The Rule
+
+No raw `extern` declarations inside `.c` files. All cross-module variable sharing must go through a header. For HAL peripheral handles, the preferred pattern is a getter function rather than a raw `extern` variable.
+
+#### Why Getters Over Raw `extern` — and Why It Matters More on an RTOS
+
+On bare-metal, execution order is linear and deterministic. On FreeRTOS, the scheduler decides which task runs when. A raw `extern` handle shared across modules carries no information about ownership, initialization order, or which execution contexts are allowed to touch it. If two tasks both reference `extern USBD_HandleTypeDef hUsbDeviceFS` there is nothing at the call site that signals which task holds a lock or whether the handle is initialized yet.
+
+A getter function (`USB_GetDeviceHandle()`) does not solve thread-safety on its own, but it:
+- Gives you a single intercept point if you later need to add an assertion or a mutex check.
+- Makes ownership explicit: the `.c` file that defines the handle and provides the getter is unambiguously the owner.
+- Removes the handle type from the public interface of any module that does not need to know about it.
+
+In this project the thread-safety risk is low — USB handle access is dominated by ISR context, and Modbus-level access is serialized by a mutex in `modbus_port_ownership.c`. The getters are policy, not a runtime fix.
+
+#### Why Some Handles Live Entirely in Their Own File
+
+For `hpcd_USB_FS` (`Src/hw/usbd_conf.c`) and `htim6` (`Src/hw/stm32l5xx_hal_timebase_tim.c`), the ISR handlers were moved into the same file that defines the handle. The handle never leaves its translation unit — no `extern` of any kind is needed.
+
+#### Intentionally Left as `extern` (in Headers)
+
+| Symbol | File | Reason |
+|--------|------|--------|
+| `USBD_Interface_fops_FS`, `CDC_Desc` | `Inc/hw/usbd_cdc_if.h`, `Inc/hw/usbd_desc.h` | Initialization-time constants passed once to middleware at startup. No mutation, no concurrent access, no encapsulation benefit from a getter. |
+| `usbRxStream` | `Inc/modbus/portserial_usb.h` | FreeRTOS stream buffer written directly from an ISR (`CDC_Receive_FS`). A wrapper function would add indirection in ISR context with no benefit. Declared in a header (not a `.c` file), so CLAUDE.md is satisfied. |
+| `SystemCoreClock` | `Inc/app/FreeRTOSConfig.h` | Defined by CMSIS/STM32 startup code. No application source file owns it; there is nothing to wrap. |
+| Linker symbols (`_end`, `_estack`, `_Min_Stack_Size`) | `Src/sysmem.c` | Defined by the linker script. Only expressible as `extern`; no source file allocates them. |
+| Weak stubs (`__io_putchar`, `__io_getchar`) | `Src/syscalls.c` | Newlib weak-symbol pattern. No source to wrap. |
+
+#### What Was Not Changed
+
+`Drivers/` (HAL + CMSIS) and `Middlewares/` (FreeRTOS, FreeModbus, USB Device Library) are vendor/third-party code and are never modified. The STM32 USB Device Library's callback interface (`USBD_CDC_ItfTypeDef`) requires the CDC layer (`usbd_cdc_if.c`) to hold a reference to the device handle in order to re-arm the RX endpoint after each receive — fully hiding `hUsbDeviceFS` from `usbd_cdc_if.c` would require changing that middleware interface. The getter (`USB_GetDeviceHandle()`) is the practical ceiling without touching vendor code.
+
+---
+
 ## Complaints
 
 STM32CubeMX is convenient for project scaffolding but its generated code structure conflicts with maintainability goals:

--- a/Src/hw/crc.c
+++ b/Src/hw/crc.c
@@ -87,5 +87,10 @@ void HAL_CRC_MspDeInit(CRC_HandleTypeDef* crcHandle)
 
 /* USER CODE BEGIN 1 */
 
+CRC_HandleTypeDef * CRC_GetHandle(void)
+{
+    return &hcrc;
+}
+
 /* USER CODE END 1 */
 

--- a/Src/hw/stm32l5xx_hal_timebase_tim.c
+++ b/Src/hw/stm32l5xx_hal_timebase_tim.c
@@ -115,3 +115,8 @@ void HAL_ResumeTick(void)
   __HAL_TIM_ENABLE_IT(&htim6, TIM_IT_UPDATE);
 }
 
+void TIM6_IRQHandler(void)
+{
+  HAL_TIM_IRQHandler(&htim6);
+}
+

--- a/Src/hw/stm32l5xx_it.c
+++ b/Src/hw/stm32l5xx_it.c
@@ -18,15 +18,8 @@
 #include "main.h"
 #include "stm32l5xx_it.h"
 
-extern PCD_HandleTypeDef hpcd_USB_FS;
-
 // @todo [2026-04-26] Use DMA or remove it
 //extern DMA_HandleTypeDef hdma_usart2_tx;
-
-// Not using here, modbus handles it directly outside of FreeRTOS and CubeMX
-//extern UART_HandleTypeDef huart2;
-
-extern TIM_HandleTypeDef htim6;
 
 /******************************************************************************/
 /*           Cortex Processor Interruption and Exception Handlers          */
@@ -49,14 +42,6 @@ void DMA1_Channel3_IRQHandler(void)
 }
 
 /**
-  * @brief This function handles TIM6 global interrupt.
-  */
-void TIM6_IRQHandler(void)
-{
-  HAL_TIM_IRQHandler(&htim6);
-}
-
-/**
   * @brief This function handles USART2 global interrupt / USART2 wake-up interrupt through EXTI line 27.
   */
  /* Not using here, modbus handles it directly outside of FreeRTOS and CubeMX
@@ -64,11 +49,3 @@ void USART2_IRQHandler(void)
 {
   HAL_UART_IRQHandler(&huart2);
 }*/
-
-/**
-  * @brief This function handles USB FS global interrupt / USB FS wake-up interrupt through EXTI line 34.
-  */
-void USB_FS_IRQHandler(void)
-{
-  HAL_PCD_IRQHandler(&hpcd_USB_FS);
-}

--- a/Src/hw/usart.c
+++ b/Src/hw/usart.c
@@ -20,6 +20,11 @@
 UART_HandleTypeDef huart2;
 static UART_HandleTypeDef * const pHandle = &huart2;
 
+UART_HandleTypeDef * USART2_GetHandle(void)
+{
+    return &huart2;
+}
+
 // @todo [2026-4-12] Can we utilize DMA here?  Freemodbus may need modification.
 DMA_HandleTypeDef hdma_usart2_tx;
 

--- a/Src/hw/usb_device.c
+++ b/Src/hw/usb_device.c
@@ -28,7 +28,6 @@
 
 /* USB Device Core handle declaration. */
 USBD_HandleTypeDef hUsbDeviceFS;
-extern USBD_DescriptorsTypeDef CDC_Desc;
 
 
 /**
@@ -42,5 +41,14 @@ void MX_USB_Device_Init(void)
   assert(USBD_OK == USBD_RegisterClass(&hUsbDeviceFS, &USBD_CDC));
   assert(USBD_OK == USBD_CDC_RegisterInterface(&hUsbDeviceFS, &USBD_Interface_fops_FS));
   assert(USBD_OK == USBD_Start(&hUsbDeviceFS));
+}
+
+/**
+ * @brief  Returns a pointer to the USB device handle owned by this module.
+ * @retval Pointer to the USBD_HandleTypeDef instance.
+ */
+USBD_HandleTypeDef * USB_GetDeviceHandle(void)
+{
+    return &hUsbDeviceFS;
 }
 

--- a/Src/hw/usbd_cdc_if.c
+++ b/Src/hw/usbd_cdc_if.c
@@ -17,6 +17,7 @@
   */
 
 #include "usbd_cdc_if.h"
+#include "usb_device.h"
 
 /* portserial_usb.h provides two things used in this file:
  *   1. extern StreamBufferHandle_t usbRxStream — the FreeRTOS stream buffer
@@ -34,8 +35,6 @@
 uint8_t UserRxBufferFS[APP_RX_DATA_SIZE];
 /** Data to send over USB CDC are stored in this buffer   */
 uint8_t UserTxBufferFS[APP_TX_DATA_SIZE];
-
-extern USBD_HandleTypeDef hUsbDeviceFS;
 
 /** USBD_CDC_IF_Private_FunctionPrototypes USBD_CDC_IF_Private_FunctionPrototypes */
 static int8_t CDC_Init_FS(void);
@@ -62,8 +61,8 @@ USBD_CDC_ItfTypeDef USBD_Interface_fops_FS =
 static int8_t CDC_Init_FS(void)
 {
   /* Set Application Buffers */
-  USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, 0);
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
+  USBD_CDC_SetTxBuffer(USB_GetDeviceHandle(), UserTxBufferFS, 0);
+  USBD_CDC_SetRxBuffer(USB_GetDeviceHandle(), UserRxBufferFS);
   return (USBD_OK);
 }
 
@@ -171,8 +170,8 @@ static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
   xStreamBufferSendFromISR(usbRxStream, Buf, *Len, &xHigherPriorityTaskWoken);
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
-  USBD_CDC_ReceivePacket(&hUsbDeviceFS);
+  USBD_CDC_SetRxBuffer(USB_GetDeviceHandle(), UserRxBufferFS);
+  USBD_CDC_ReceivePacket(USB_GetDeviceHandle());
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
   return (USBD_OK);
 }
@@ -190,7 +189,7 @@ static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
   */
 uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
 {
-  USBD_CDC_HandleTypeDef * hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
+  USBD_CDC_HandleTypeDef * hcdc = (USBD_CDC_HandleTypeDef*)USB_GetDeviceHandle()->pClassData;
   uint8_t result;
 
   if (hcdc->TxState != 0)
@@ -199,8 +198,8 @@ uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
   }
   else
   {
-    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, Buf, Len);
-    result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
+    USBD_CDC_SetTxBuffer(USB_GetDeviceHandle(), Buf, Len);
+    result = USBD_CDC_TransmitPacket(USB_GetDeviceHandle());
   }
 
   return result;

--- a/Src/hw/usbd_conf.c
+++ b/Src/hw/usbd_conf.c
@@ -679,3 +679,8 @@ USBD_StatusTypeDef USBD_Get_USB_Status(HAL_StatusTypeDef hal_status)
   }
   return usb_status;
 }
+
+void USB_FS_IRQHandler(void)
+{
+  HAL_PCD_IRQHandler(&hpcd_USB_FS);
+}


### PR DESCRIPTION
Remove all bare extern declarations from .c files (CLAUDE.md violation) and convert exported HAL handles to getter functions for explicit ownership. ISRs for TIM6 and USB_FS moved into the same .c files that define their handles, eliminating the need for any extern at all. Document the policy and intentional exceptions in README.

Also updated CLAUDE.md to specify a coding standard